### PR TITLE
[CHANGE] modal templates to use django_bootstrap5 and remove deprecated bootstrap loading

### DIFF
--- a/assets/templates/assets/bundles/settings-bundles.html
+++ b/assets/templates/assets/bundles/settings-bundles.html
@@ -1,6 +1,5 @@
 {% load i18n %}
 {% load static %}
-{% load bootstrap %}
 {% load sri %}
 
 {% sri_static 'assets/css/assets.css' %}

--- a/assets/templates/assets/partials/modal/confirm.html
+++ b/assets/templates/assets/partials/modal/confirm.html
@@ -1,6 +1,5 @@
 {% load i18n %}
 {% load static %}
-{% load bootstrap %}
 
 <!-- Approve Request Modal -->
 <div class="modal fade" id="assets-confirm-request" tabindex="-1" role="dialog" aria-hidden="true">

--- a/assets/templates/assets/partials/modal/multi-order.html
+++ b/assets/templates/assets/partials/modal/multi-order.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load static %}
-{% load bootstrap %}
+{% load django_bootstrap5 %}
 
 <!-- Approve Request Modal -->
 <div class="modal fade" id="assets-multi-request" tabindex="-1" role="dialog" aria-hidden="true">
@@ -21,7 +21,7 @@
                         <div class="d-flex align-items-center gap-2">
                             {% csrf_token %}
                             <fieldset class="assets-multi-request-form flex-grow-1">
-                                {{ forms.multi_request|bootstrap }}
+                                {% bootstrap_form forms.multi_request %}
                             </fieldset>
                         </div>
                     </form>

--- a/assets/templates/assets/partials/modal/single-order.html
+++ b/assets/templates/assets/partials/modal/single-order.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load static %}
-{% load bootstrap %}
+{% load django_bootstrap5 %}
 
 <!-- Approve Request Modal -->
 <div class="modal fade" id="assets-single-request" tabindex="-1" role="dialog" aria-hidden="true">
@@ -21,7 +21,7 @@
                         <div class="d-flex align-items-center gap-2">
                             {% csrf_token %}
                             <fieldset class="assets-single-request-form flex-grow-1">
-                                {{ forms.single_request|bootstrap }}
+                                {% bootstrap_form forms.single_request %}
                             </fieldset>
                             <button id="modal-button-buy-single-request" type="button" class="btn btn-primary mt-4">
                                 {% trans "All" %}


### PR DESCRIPTION
## Description

### Changed
- modal templates to use django_bootstrap5 and remove deprecated bootstrap loading

## Type of Changes
Please select the type of changes made in this pull request:
- [ ] Bug Fix (non-breaking change which fixes an Issue)
- [ ] New Feature (non-breaking change)
- [ ] Other (please specify):

## Checklist
Please ensure the following before submitting your pull request:
- [x] I have read the [contributing guidelines](https://github.com/Geuthur/aa-assets/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] All new and existing tests passed.
